### PR TITLE
Add VSC events + delete require cache for package.json on change

### DIFF
--- a/src/events/onDidChangeTextDocument.js
+++ b/src/events/onDidChangeTextDocument.js
@@ -9,7 +9,7 @@ module.exports = class extends Event {
 		super(...args, { emitter: workspace });
 	}
 
-	async run({ document: fileName }) {
+	async run({ document: { fileName } }) {
 		const fn = resolve(workspace.rootPath, 'package.json');
 		if (fileName !== fn) return undefined;
 		return delete require.cache[require.resolve(fn)];

--- a/src/events/onDidChangeTextDocument.js
+++ b/src/events/onDidChangeTextDocument.js
@@ -6,7 +6,7 @@ const { Event } = require('../lib');
 module.exports = class extends Event {
 
 	constructor(...args) {
-		super(...args, { container: workspace });
+		super(...args, { emitter: workspace });
 	}
 
 	async run({ document: fileName }) {

--- a/src/events/onDidChangeTextDocument.js
+++ b/src/events/onDidChangeTextDocument.js
@@ -1,0 +1,18 @@
+const { resolve } = require('path');
+const { workspace } = require('vscode');
+
+const { Event } = require('../lib');
+
+module.exports = class extends Event {
+
+	constructor(...args) {
+		super(...args, { container: workspace });
+	}
+
+	async run({ document: fileName }) {
+		const fn = resolve(workspace.rootPath, 'package.json');
+		if (fileName !== fn) return undefined;
+		return delete require.cache[require.resolve(fn)];
+	}
+
+};

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const { join } = require('path');
-const { commands, window, Disposable } = require('vscode');
+const { commands, Disposable } = require('vscode');
 
 class Extension {
 
@@ -23,7 +23,7 @@ class Extension {
 			const loc = join(__dirname, 'events', eventLoc);
 			try {
 				const event = new (require(loc))(context, loc);
-				window[eventLoc](event._run, event, subscriptions);
+				event.container[event.name](event._run, event, subscriptions);
 			} catch (err) {
 				const error = err.message.endsWith('not a constructor') ? new TypeError(`Exported Structure Not A Class`) : err;
 				console.error(`${error}: ${loc}`);

--- a/src/extension.js
+++ b/src/extension.js
@@ -5,7 +5,7 @@ const { commands, Disposable } = require('vscode');
 class Extension {
 
 	static async activate(context) {
-		let subscriptions = [];
+		const subscriptions = [];
 
 		const cmds = await fs.readdir(join(__dirname, 'commands'));
 		for (const cmdLoc of cmds) {
@@ -23,7 +23,7 @@ class Extension {
 			const loc = join(__dirname, 'events', eventLoc);
 			try {
 				const event = new (require(loc))(context, loc);
-				event.container[event.name](event._run, event, subscriptions);
+				event.emitter[event.name](event._run, event, subscriptions);
 			} catch (err) {
 				const error = err.message.endsWith('not a constructor') ? new TypeError(`Exported Structure Not A Class`) : err;
 				console.error(`${error}: ${loc}`);

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,10 +1,12 @@
 const fs = require('fs-extra');
 const { join } = require('path');
-const { commands } = require('vscode');
+const { commands, window, Disposable } = require('vscode');
 
 class Extension {
 
 	static async activate(context) {
+		let subscriptions = [];
+
 		const cmds = await fs.readdir(join(__dirname, 'commands'));
 		for (const cmdLoc of cmds) {
 			const loc = join(__dirname, 'commands', cmdLoc);
@@ -16,10 +18,24 @@ class Extension {
 				console.error(`${error}: ${loc}`);
 			}
 		}
+		const events = await fs.readdir(join(__dirname, 'events'));
+		for (const eventLoc of events) {
+			const loc = join(__dirname, 'events', eventLoc);
+			try {
+				const event = new (require(loc))(context, loc);
+				window[eventLoc](event._run, event, subscriptions);
+			} catch (err) {
+				const error = err.message.endsWith('not a constructor') ? new TypeError(`Exported Structure Not A Class`) : err;
+				console.error(`${error}: ${loc}`);
+			}
+		}
+
+		this._disposable = Disposable.from(...subscriptions);
 	}
 
 	static deactivate() {
 		// commands are already disposed because it's loaded in context.subscriptions...
+		if (this._disposable) this._disposable.dispose();
 	}
 
 }

--- a/src/lib/Event.js
+++ b/src/lib/Event.js
@@ -1,0 +1,30 @@
+const { basename } = require('path');
+const { workspace, window } = require('vscode');
+
+class Event {
+
+	constructor(context, location, options = {}) {
+		this.context = context;
+		this.location = location;
+		this.name = options.name || basename(this.location, '.js');
+		this.container = options.container;
+	}
+
+	_run() {
+		// common checks
+		if (!workspace.rootPath) return undefined;
+
+		return this.run().catch(err => {
+			if (err === undefined) return false;
+			if (typeof err === 'string') return window.showErrorMessage(err);
+			return console.error(err);
+		});
+	}
+
+	run() {
+		// stub
+	}
+
+}
+
+module.exports = Event;

--- a/src/lib/Event.js
+++ b/src/lib/Event.js
@@ -10,11 +10,11 @@ class Event {
 		this.container = options.container;
 	}
 
-	_run() {
+	_run(...args) {
 		// common checks
 		if (!workspace.rootPath) return undefined;
 
-		return this.run().catch(err => {
+		return this.run(...args).catch(err => {
 			if (err === undefined) return false;
 			if (typeof err === 'string') return window.showErrorMessage(err);
 			return console.error(err);

--- a/src/lib/Event.js
+++ b/src/lib/Event.js
@@ -7,7 +7,7 @@ class Event {
 		this.context = context;
 		this.location = location;
 		this.name = options.name || basename(this.location, '.js');
-		this.container = options.container;
+		this.emitter = options.emitter;
 	}
 
 	_run(...args) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,5 @@
 module.exports = {
 	Command: require('./Command'),
+	Event: require('./Event'),
 	eventStore: require('./eventStore')
 };


### PR DESCRIPTION
When you execute a command, the `baseDir` is calculated and cached. But if you change the `package.json#main`, the `baseDir` is not updated (or reset) and can lead to create files in the wrong place.

Currently (with this PR), the commands you already executed since the extension activation are not updated, only the new ones will use a correct `baseDir`.

I wonder if `baseDir` would be in a better place outside a command instance (i.e. only **one** `baseDir` for the whole extension)